### PR TITLE
feat(signals): remove computed() and simplify derive()

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -11,7 +11,7 @@ At the core of **purify.js** is a powerful signal-based reactivity system. Unlik
 reactivity with minimal abstractions:
 
 ```ts
-import { computed, ref, sync } from "@purifyjs/core";
+import { ref, sync } from "@purifyjs/core";
 
 // Create a writable signal with an initial value
 const count = ref(0);
@@ -34,7 +34,7 @@ All signals in **purify.js** are built on the `Sync` class:
 
 - `Sync` is the base class for all signals
 - `Sync.Ref` extends `Sync` to add mutability (for read-write signals)
-- `computed()` creates a `Sync` with automatic dependency tracking
+
 
 While you can create signals with constructors like `new Sync()` or `new Sync.Ref()`, **purify.js** provides convenient function aliases:
 
@@ -52,31 +52,13 @@ const count = new Sync.Ref(0); // Constructor
 
 ### Signal Types
 
-**purify.js** offers three kinds of signals:
+**purify.js** offers two kinds of signals:
 
 #### 1. `ref(initialValue)`
 
 A mutable signal you can both read and write.
 
-#### 2. `computed(() => expression)`
-
-A derived signal that automatically recalculates when its dependencies change.
-
-```ts
-const count = ref(0);
-const doubled = computed(() => count.get() * 2);
-
-console.log(doubled.get()); // 0
-count.set(5);
-console.log(doubled.get()); // 10
-```
-
-> **Note:** Computed signals are clever: they only recalculate when both:
->
-> - One of their dependencies changes
-> - Someone is actively using the computed value
-
-#### 3. `sync(setter => {...})`
+#### 2. `sync(setter => {...})`
 
 A signal with manual control over its lifecycle:
 
@@ -120,33 +102,29 @@ message.follow(console.log); // "The count is 0" when count changes
 
 The `.derive()` method creates a new signal that updates whenever the source signal changes.
 
-### derive() vs computed()
-
-Both `.derive()` and `computed()` create reactive values, but they serve different purposes:
-
-```ts
-// derive() transforms a single signal
-const count = ref(0);
-const doubled = count.derive((n) => n * 2);
-
-// computed() can depend on multiple signals
-const count1 = ref(0);
-const count2 = ref(0);
-const sum = computed(() => count1.get() + count2.get());
-```
-
-Key differences:
-
-| Feature                 | `.derive()`                                      | `computed()`                                                |
-| ----------------------- | ------------------------------------------------ | ----------------------------------------------------------- |
-| **Dependency tracking** | Always depends on the source signal              | Automatically tracks any signal accessed in its callback    |
-| **Chaining**            | Chainable for multiple transformations           | Creates standalone signals                                  |
-| **Usage context**       | Perfect for transforming a single signal's value | Better when combining multiple signals or for complex logic |
-
 Example of chaining with `.derive()`:
 
 ```ts
 count.derive((n) => n * 2).derive((n) => `Value: ${n}`);
+```
+
+### Combining Multiple Signals
+
+When you need to combine multiple signals, use `combine()`:
+
+```ts
+import { combine } from "@purifyjs/core";
+
+const firstName = ref("John");
+const lastName = ref("Doe");
+
+// Combine signals into a single signal
+const fullName = combine({ firstName, lastName }).derive(
+    ({ firstName, lastName }) => `${firstName} ${lastName}`
+);
+
+fullName.follow(console.log); // "John Doe"
+firstName.set("Jane");        // Logs "Jane Doe"
 ```
 
 ---
@@ -282,7 +260,7 @@ To avoid these issues with signal containers, consider:
 1. Using property setters for text content where possible:
    ```ts
    // Better than append$(textSignal) for simple text
-   div().textContent(computed(() => `Welcome ${currentUser.get().name}`));
+   div().textContent(currentUser.derive((user) => `Welcome ${user.name}`));
    ```
 
 2. Creating custom helper functions for specific DOM updates (see the "Helper Functions" section)
@@ -364,7 +342,7 @@ export function useReplaceChildren<T extends Member>(signal: Sync<T>): Lifecycle
 }
 
 // Using the helper
-div().$bind(useReplaceChildren(computed(() => ["Welcome", currentUser.get()])));
+div().$bind(useReplaceChildren(currentUser.derive((user) => ["Welcome", user])));
 
 // Helper for class toggling based on a signal
 export function useToggleClass(className: string, condition: Sync<boolean>): Lifecycle.OnConnected {
@@ -584,7 +562,7 @@ class CounterElement extends WithLifecycle(HTMLElement) {
 
 **purify.js** provides a minimalist yet powerful approach to building reactive UIs:
 
-- Use signals (`ref`, `computed`, `sync`) for reactivity
+- Use signals (`ref`, `sync`) for reactivity
 - Create elements with the `tags` proxy
 - Configure elements with the `Builder` pattern
 - Use `$` suffix methods for working with signals and arrays

--- a/core/signals.test.ts
+++ b/core/signals.test.ts
@@ -6,268 +6,268 @@ import { combine, ref, Sync, sync } from "./signals.ts";
 function _(_fn: () => void) {}
 
 _(() => {
-	const signalSignal = sync<number>(() => {});
-	const stateSignal = ref<number>(0);
-	const derivedSignal = stateSignal.derive((n) => n * 2);
+    const signalSignal = sync<number>(() => {});
+    const stateSignal = ref<number>(0);
+    const derivedSignal = stateSignal.derive((n) => n * 2);
 
-	/// @ts-expect-error read-only
-	signalSignal.val = 0;
-	stateSignal.val = 0;
-	/// @ts-expect-error read-only
-	derivedSignal.val = 0;
+    /// @ts-expect-error read-only
+    signalSignal.val = 0;
+    stateSignal.val = 0;
+    /// @ts-expect-error read-only
+    derivedSignal.val = 0;
 
-	function acceptSignal(_: Sync<unknown>) {}
-	function acceptref(_: Sync.Ref<unknown>) {}
+    function acceptSignal(_: Sync<unknown>) {}
+    function acceptref(_: Sync.Ref<unknown>) {}
 
-	acceptSignal(signalSignal);
-	acceptSignal(stateSignal);
-	acceptSignal(derivedSignal);
+    acceptSignal(signalSignal);
+    acceptSignal(stateSignal);
+    acceptSignal(derivedSignal);
 
-	/// @ts-expect-error read-only
-	acceptref(signalSignal);
-	acceptref(stateSignal);
-	/// @ts-expect-error read-only
-	acceptref(derivedSignal);
+    /// @ts-expect-error read-only
+    acceptref(signalSignal);
+    acceptref(stateSignal);
+    /// @ts-expect-error read-only
+    acceptref(derivedSignal);
 });
 
 Deno.test("Derive counter with immediate basics", () => {
-	const value = ref(0);
-	const double = value.derive((v) => v * 2);
+    const value = ref(0);
+    const double = value.derive((v) => v * 2);
 
-	const results: number[] = [];
-	double.follow((value) => results.push(value), true);
+    const results: number[] = [];
+    double.follow((value) => results.push(value), true);
 
-	for (let i = 0; i < 8; i++) {
-		value.val++;
-	}
+    for (let i = 0; i < 8; i++) {
+        value.val++;
+    }
 
-	assertStrictEquals(results.length, 9);
-	assertStrictEquals(results[0], 0);
-	assertStrictEquals(results[8], 16);
+    assertStrictEquals(results.length, 9);
+    assertStrictEquals(results[0], 0);
+    assertStrictEquals(results[8], 16);
 });
 
 Deno.test("Derive counter without immediate basics", () => {
-	const value = ref(0);
-	const double = value.derive((v) => v * 2);
+    const value = ref(0);
+    const double = value.derive((v) => v * 2);
 
-	const results: number[] = [];
-	double.follow((value) => results.push(value));
+    const results: number[] = [];
+    double.follow((value) => results.push(value));
 
-	for (let i = 0; i < 8; i++) {
-		value.val++;
-	}
+    for (let i = 0; i < 8; i++) {
+        value.val++;
+    }
 
-	assertStrictEquals(results.length, 8);
-	assertStrictEquals(results[0], 2);
-	assertStrictEquals(results[7], 16);
+    assertStrictEquals(results.length, 8);
+    assertStrictEquals(results[0], 2);
+    assertStrictEquals(results[7], 16);
 });
 
 Deno.test("Combine multiple signals", () => {
-	const a = ref(0);
-	const b = ref(0);
-	const ab = combine({ a, b }).derive(({ a, b }) => `${a},${b}`);
+    const a = ref(0);
+    const b = ref(0);
+    const ab = combine({ a, b }).derive(({ a, b }) => `${a},${b}`);
 
-	const results: string[] = [];
-	ab.follow((ab) => results.push(ab));
+    const results: string[] = [];
+    ab.follow((ab) => results.push(ab));
 
-	for (let i = 0; i < 3; i++) {
-		b.val++;
-		a.val++;
-	}
+    for (let i = 0; i < 3; i++) {
+        b.val++;
+        a.val++;
+    }
 
-	assertStrictEquals(results.length, 6);
-	assertStrictEquals(results[0], "0,1");
-	assertStrictEquals(results[5], "3,3");
+    assertStrictEquals(results.length, 6);
+    assertStrictEquals(results[0], "0,1");
+    assertStrictEquals(results[5], "3,3");
 });
 
 Deno.test("Derived signal multi follower should call getter once", () => {
-	let counter = 0;
-	const a = ref(0);
-	const b = a.derive((value) => {
-		counter++;
-		return value;
-	});
-	b.follow(() => {});
-	b.follow(() => {});
-	b.follow(() => {});
-	b.follow(() => {});
+    let counter = 0;
+    const a = ref(0);
+    const b = a.derive((value) => {
+        counter++;
+        return value;
+    });
+    b.follow(() => {});
+    b.follow(() => {});
+    b.follow(() => {});
+    b.follow(() => {});
 
-	a.val++;
+    a.val++;
 
-	assertStrictEquals(counter, 1 + 1); // +1 for the initial computation
+    assertStrictEquals(counter, 1 + 1); // +1 for the initial computation
 });
 
 Deno.test("Derived signal shouldn't call followers if the value is the same as the previous value", () => {
-	const a = ref(0);
-	const b = a.derive((val) => val % 2);
-	const results: unknown[] = [];
-	b.follow((value) => {
-		results.push(value);
-	});
+    const a = ref(0);
+    const b = a.derive((val) => val % 2);
+    const results: unknown[] = [];
+    b.follow((value) => {
+        results.push(value);
+    });
 
-	a.val = 1;
-	a.val = 3;
-	a.val = 2;
+    a.val = 1;
+    a.val = 3;
+    a.val = 2;
 
-	assertStrictEquals(results.length, 2);
-	assertStrictEquals(results[0], 1);
-	assertStrictEquals(results[1], 0);
+    assertStrictEquals(results.length, 2);
+    assertStrictEquals(results[0], 1);
+    assertStrictEquals(results[1], 0);
 });
 
 Deno.test("Derived signal should update as many times as the source changes", () => {
-	let counter = 0;
-	const a = ref(0);
-	const b = a.derive((value) => {
-		counter++;
-		return value;
-	});
-	b.follow(() => {});
-	b.follow(() => {});
+    let counter = 0;
+    const a = ref(0);
+    const b = a.derive((value) => {
+        counter++;
+        return value;
+    });
+    b.follow(() => {});
+    b.follow(() => {});
 
-	a.val++;
-	a.val++;
+    a.val++;
+    a.val++;
 
-	assertStrictEquals(counter, 2 + 1); // +1 for the initial computation
+    assertStrictEquals(counter, 2 + 1); // +1 for the initial computation
 });
 
 Deno.test("Derived signal shouldn't run without followers", () => {
-	let counter = 0;
-	const a = ref(0);
-	a.derive((value) => {
-		counter++;
-		return value;
-	});
+    let counter = 0;
+    const a = ref(0);
+    a.derive((value) => {
+        counter++;
+        return value;
+    });
 
-	a.val++;
+    a.val++;
 
-	assertStrictEquals(counter, 0);
+    assertStrictEquals(counter, 0);
 });
 
 Deno.test("Derived signal shouldn't compute without followers", () => {
-	let counter = 0;
-	const a = ref(0);
-	a.derive((value) => {
-		counter++;
-		return value;
-	});
+    let counter = 0;
+    const a = ref(0);
+    a.derive((value) => {
+        counter++;
+        return value;
+    });
 
-	assertStrictEquals(counter, 0);
+    assertStrictEquals(counter, 0);
 });
 
 Deno.test("State, no infinite follower emit", () => {
-	const a = ref(0);
-	let counter = 0;
-	function follower() {
-		// Prevent infinite loop
-		if (counter > 8) return;
+    const a = ref(0);
+    let counter = 0;
+    function follower() {
+        // Prevent infinite loop
+        if (counter > 8) return;
 
-		a.follow(() => {
-			counter++;
-			follower();
-		});
-	}
-	follower();
+        a.follow(() => {
+            counter++;
+            follower();
+        });
+    }
+    follower();
 
-	a.val++;
+    a.val++;
 
-	assertStrictEquals(counter, 1);
+    assertStrictEquals(counter, 1);
 });
 
 Deno.test("Deep derivation shouldn't run multiple times", () => {
-	const a = ref(0);
-	let counter = 0;
+    const a = ref(0);
+    let counter = 0;
 
-	a.derive((value) => {
-		counter++;
-		return value;
-	})
-		.derive((value) => value)
-		.derive((value) => value)
-		.derive((value) => value)
-		.derive((value) => value)
-		.follow(() => {});
+    a.derive((value) => {
+        counter++;
+        return value;
+    })
+        .derive((value) => value)
+        .derive((value) => value)
+        .derive((value) => value)
+        .derive((value) => value)
+        .follow(() => {});
 
-	assertStrictEquals(counter, 1);
+    assertStrictEquals(counter, 1);
 });
 
 Deno.test("State should start on get, if there are no followers", () => {
-	const a = ref("abc");
+    const a = ref("abc");
 
-	const b = a
-		.derive((value) => value)
-		.derive((value) => value)
-		.derive((value) => value)
-		.derive((value) => value);
+    const b = a
+        .derive((value) => value)
+        .derive((value) => value)
+        .derive((value) => value)
+        .derive((value) => value);
 
-	assertStrictEquals(b.val, "abc");
+    assertStrictEquals(b.val, "abc");
 });
 
 Deno.test("Combine should work with object of different types", () => {
-	const num = ref(42);
-	const str = ref("hello");
-	const bool = ref(true);
+    const num = ref(42);
+    const str = ref("hello");
+    const bool = ref(true);
 
-	const combined = combine({ num, str, bool });
-	const results: { num: number; str: string; bool: boolean }[] = [];
+    const combined = combine({ num, str, bool });
+    const results: { num: number; str: string; bool: boolean }[] = [];
 
-	combined.follow((vals) => results.push(vals), true);
+    combined.follow((vals) => results.push(vals), true);
 
-	num.val = 100;
-	str.val = "world";
-	bool.val = false;
+    num.val = 100;
+    str.val = "world";
+    bool.val = false;
 
-	assertStrictEquals(results.length, 4);
-	assertStrictEquals(results[0]!.num, 42);
-	assertStrictEquals(results[0]!.str, "hello");
-	assertStrictEquals(results[0]!.bool, true);
-	assertStrictEquals(results[3]!.num, 100);
-	assertStrictEquals(results[3]!.str, "world");
-	assertStrictEquals(results[3]!.bool, false);
+    assertStrictEquals(results.length, 4);
+    assertStrictEquals(results[0]!.num, 42);
+    assertStrictEquals(results[0]!.str, "hello");
+    assertStrictEquals(results[0]!.bool, true);
+    assertStrictEquals(results[3]!.num, 100);
+    assertStrictEquals(results[3]!.str, "world");
+    assertStrictEquals(results[3]!.bool, false);
 });
 
 Deno.test("Combine derived chain", () => {
-	const a = ref(1);
-	const b = ref(2);
-	const sum = combine({ a, b }).derive(({ a, b }) => a + b);
+    const a = ref(1);
+    const b = ref(2);
+    const sum = combine({ a, b }).derive(({ a, b }) => a + b);
 
-	const results: number[] = [];
-	sum.follow((val) => results.push(val), true);
+    const results: number[] = [];
+    sum.follow((val) => results.push(val), true);
 
-	a.val = 10;
-	b.val = 20;
+    a.val = 10;
+    b.val = 20;
 
-	assertStrictEquals(results.length, 3);
-	assertStrictEquals(results[0], 3);
-	assertStrictEquals(results[1], 12);
-	assertStrictEquals(results[2], 30);
+    assertStrictEquals(results.length, 3);
+    assertStrictEquals(results[0], 3);
+    assertStrictEquals(results[1], 12);
+    assertStrictEquals(results[2], 30);
 });
 
 Deno.test("Infinite loop test", () => {
-	let counter = 0;
-	const a = new Sync(() => {
-		counter++;
-		if (counter > 100) return;
-		a.val;
-	});
-	a.val;
+    let counter = 0;
+    const a = new Sync(() => {
+        counter++;
+        if (counter > 100) return;
+        a.val;
+    });
+    a.val;
 
-	assertStrictEquals(counter, 1);
+    assertStrictEquals(counter, 1);
 });
 
 Deno.test("No stop leak", () => {
-	let counter = 0;
-	// deno-lint-ignore prefer-const
-	let unfollow: Sync.Unfollower;
-	const a = new Sync(() => {
-		if (typeof unfollow !== "undefined") {
-			unfollow();
-		}
+    let counter = 0;
+    // deno-lint-ignore prefer-const
+    let unfollow: Sync.Unfollower;
+    const a = new Sync(() => {
+        if (typeof unfollow !== "undefined") {
+            unfollow();
+        }
 
-		return () => {
-			counter++;
-		};
-	});
-	unfollow = a.follow(() => {});
-	unfollow();
-	assertStrictEquals(counter, 1);
+        return () => {
+            counter++;
+        };
+    });
+    unfollow = a.follow(() => {});
+    unfollow();
+    assertStrictEquals(counter, 1);
 });

--- a/core/signals.test.ts
+++ b/core/signals.test.ts
@@ -1,267 +1,273 @@
 /// <reference lib="deno.ns" />
 
 import { assertStrictEquals } from "jsr:@std/assert";
-import { computed, ref, Sync, sync } from "./signals.ts";
-
-function assertTupleEqual(a: unknown[], b: unknown[]) {
-    assertStrictEquals(a.length, b.length);
-    for (let i = 0; i < a.length; i++) {
-        assertStrictEquals(a[i], b[i]);
-    }
-}
+import { combine, ref, Sync, sync } from "./signals.ts";
 
 function _(_fn: () => void) {}
 
 _(() => {
-    const signalSignal = sync<number>(() => {});
-    const stateSignal = ref<number>(0);
-    const computedSignal = computed<number>(() => 0);
+	const signalSignal = sync<number>(() => {});
+	const stateSignal = ref<number>(0);
+	const derivedSignal = stateSignal.derive((n) => n * 2);
 
-    /// @ts-expect-error read-only
-    signalSignal.val = 0;
-    stateSignal.val = 0;
-    /// @ts-expect-error read-only
-    computedSignal.val = 0;
+	/// @ts-expect-error read-only
+	signalSignal.val = 0;
+	stateSignal.val = 0;
+	/// @ts-expect-error read-only
+	derivedSignal.val = 0;
 
-    function acceptSignal(_: Sync<unknown>) {}
-    function acceptref(_: Sync.Ref<unknown>) {}
+	function acceptSignal(_: Sync<unknown>) {}
+	function acceptref(_: Sync.Ref<unknown>) {}
 
-    acceptSignal(signalSignal);
-    acceptSignal(stateSignal);
-    acceptSignal(computedSignal);
+	acceptSignal(signalSignal);
+	acceptSignal(stateSignal);
+	acceptSignal(derivedSignal);
 
-    /// @ts-expect-error read-only
-    acceptref(signalSignal);
-    acceptref(stateSignal);
-    /// @ts-expect-error read-only
-    acceptref(computedSignal);
+	/// @ts-expect-error read-only
+	acceptref(signalSignal);
+	acceptref(stateSignal);
+	/// @ts-expect-error read-only
+	acceptref(derivedSignal);
 });
 
 Deno.test("Derive counter with immediate basics", () => {
-    const value = ref(0);
-    const double = computed(() => value.val * 2);
+	const value = ref(0);
+	const double = value.derive((v) => v * 2);
 
-    const results: number[] = [];
-    double.follow((value) => results.push(value), true);
+	const results: number[] = [];
+	double.follow((value) => results.push(value), true);
 
-    for (let i = 0; i < 8; i++) {
-        value.val++;
-    }
+	for (let i = 0; i < 8; i++) {
+		value.val++;
+	}
 
-    assertTupleEqual(results, [0, 2, 4, 6, 8, 10, 12, 14, 16]);
+	assertStrictEquals(results.length, 9);
+	assertStrictEquals(results[0], 0);
+	assertStrictEquals(results[8], 16);
 });
 
 Deno.test("Derive counter without immediate basics", () => {
-    const value = ref(0);
-    const double = computed(() => value.val * 2);
+	const value = ref(0);
+	const double = value.derive((v) => v * 2);
 
-    const results: number[] = [];
-    double.follow((value) => results.push(value));
+	const results: number[] = [];
+	double.follow((value) => results.push(value));
 
-    for (let i = 0; i < 8; i++) {
-        value.val++;
-    }
+	for (let i = 0; i < 8; i++) {
+		value.val++;
+	}
 
-    assertTupleEqual(results, [2, 4, 6, 8, 10, 12, 14, 16]);
+	assertStrictEquals(results.length, 8);
+	assertStrictEquals(results[0], 2);
+	assertStrictEquals(results[7], 16);
 });
 
-Deno.test("Computed multiple dependency", () => {
-    const a = ref(0);
-    const b = ref(0);
-    const ab = computed(() => `${a.val},${b.val}`);
+Deno.test("Combine multiple signals", () => {
+	const a = ref(0);
+	const b = ref(0);
+	const ab = combine({ a, b }).derive(({ a, b }) => `${a},${b}`);
 
-    const results: string[] = [];
-    ab.follow((ab) => results.push(ab));
+	const results: string[] = [];
+	ab.follow((ab) => results.push(ab));
 
-    for (let i = 0; i < 3; i++) {
-        b.val++;
-        a.val++;
-    }
+	for (let i = 0; i < 3; i++) {
+		b.val++;
+		a.val++;
+	}
 
-    assertTupleEqual(results, ["0,1", "1,1", "1,2", "2,2", "2,3", "3,3"]);
+	assertStrictEquals(results.length, 6);
+	assertStrictEquals(results[0], "0,1");
+	assertStrictEquals(results[5], "3,3");
 });
 
-Deno.test("Computed multi follower should call getter once", () => {
-    let counter = 0;
-    const a = ref(0);
-    const b = computed(() => {
-        Sync.Tracking.add(a);
-        counter++;
-    });
-    b.follow(() => {});
-    b.follow(() => {});
-    b.follow(() => {});
-    b.follow(() => {});
+Deno.test("Derived signal multi follower should call getter once", () => {
+	let counter = 0;
+	const a = ref(0);
+	const b = a.derive((value) => {
+		counter++;
+		return value;
+	});
+	b.follow(() => {});
+	b.follow(() => {});
+	b.follow(() => {});
+	b.follow(() => {});
 
-    a.val++;
+	a.val++;
 
-    assertStrictEquals(counter, 1 + 1); // +1 for the initial dependency discovery
+	assertStrictEquals(counter, 1 + 1); // +1 for the initial computation
 });
 
-Deno.test("Computed shouldn't call followers if the value is the same as the previous value", () => {
-    const a = ref(0);
-    const b = computed(() => a.val % 2);
-    const results: unknown[] = [];
-    b.follow((value) => {
-        results.push(value);
-    });
+Deno.test("Derived signal shouldn't call followers if the value is the same as the previous value", () => {
+	const a = ref(0);
+	const b = a.derive((val) => val % 2);
+	const results: unknown[] = [];
+	b.follow((value) => {
+		results.push(value);
+	});
 
-    a.val = 1;
-    a.val = 3;
-    a.val = 2;
+	a.val = 1;
+	a.val = 3;
+	a.val = 2;
 
-    assertTupleEqual(results, [1, 0]);
+	assertStrictEquals(results.length, 2);
+	assertStrictEquals(results[0], 1);
+	assertStrictEquals(results[1], 0);
 });
 
-Deno.test("Computed should update as many times as the dependencies changes", () => {
-    let counter = 0;
-    const a = ref(0);
-    const b = computed(() => {
-        Sync.Tracking.add(a);
-        counter++;
-    });
-    b.follow(() => {});
-    b.follow(() => {});
+Deno.test("Derived signal should update as many times as the source changes", () => {
+	let counter = 0;
+	const a = ref(0);
+	const b = a.derive((value) => {
+		counter++;
+		return value;
+	});
+	b.follow(() => {});
+	b.follow(() => {});
 
-    a.val++;
-    a.val++;
+	a.val++;
+	a.val++;
 
-    assertStrictEquals(counter, 2 + 1); // +1 for the initial dependency discovery
+	assertStrictEquals(counter, 2 + 1); // +1 for the initial computation
 });
 
-Deno.test("Computed shouldn't run without followers", () => {
-    let counter = 0;
-    const a = ref(0);
-    computed(() => {
-        Sync.Tracking.add(a);
-        counter++;
-    });
+Deno.test("Derived signal shouldn't run without followers", () => {
+	let counter = 0;
+	const a = ref(0);
+	a.derive((value) => {
+		counter++;
+		return value;
+	});
 
-    a.val++;
+	a.val++;
 
-    assertStrictEquals(counter, 0);
+	assertStrictEquals(counter, 0);
 });
 
-Deno.test("Computed shouldn't discover without followers", () => {
-    let counter = 0;
-    const a = ref(0);
-    computed(() => {
-        Sync.Tracking.add(a);
-        counter++;
-    });
+Deno.test("Derived signal shouldn't compute without followers", () => {
+	let counter = 0;
+	const a = ref(0);
+	a.derive((value) => {
+		counter++;
+		return value;
+	});
 
-    assertStrictEquals(counter, 0);
+	assertStrictEquals(counter, 0);
 });
 
 Deno.test("State, no infinite follower emit", () => {
-    const a = ref(0);
-    let counter = 0;
-    function follower() {
-        // Prevent infinite loop
-        if (counter > 8) return;
+	const a = ref(0);
+	let counter = 0;
+	function follower() {
+		// Prevent infinite loop
+		if (counter > 8) return;
 
-        a.follow(() => {
-            counter++;
-            follower();
-        });
-    }
-    follower();
+		a.follow(() => {
+			counter++;
+			follower();
+		});
+	}
+	follower();
 
-    a.val++;
+	a.val++;
 
-    assertStrictEquals(counter, 1);
+	assertStrictEquals(counter, 1);
 });
 
 Deno.test("Deep derivation shouldn't run multiple times", () => {
-    const a = ref(0);
-    let counter = 0;
+	const a = ref(0);
+	let counter = 0;
 
-    a.derive((value) => {
-        counter++;
-        return value;
-    })
-        .derive((value) => value)
-        .derive((value) => value)
-        .derive((value) => value)
-        .derive((value) => value)
-        .follow(() => {});
+	a.derive((value) => {
+		counter++;
+		return value;
+	})
+		.derive((value) => value)
+		.derive((value) => value)
+		.derive((value) => value)
+		.derive((value) => value)
+		.follow(() => {});
 
-    assertStrictEquals(counter, 1);
+	assertStrictEquals(counter, 1);
 });
 
 Deno.test("State should start on get, if there are no followers", () => {
-    const a = ref("abc");
+	const a = ref("abc");
 
-    const b = a
-        .derive((value) => value)
-        .derive((value) => value)
-        .derive((value) => value)
-        .derive((value) => value);
+	const b = a
+		.derive((value) => value)
+		.derive((value) => value)
+		.derive((value) => value)
+		.derive((value) => value);
 
-    assertStrictEquals(b.val, "abc");
+	assertStrictEquals(b.val, "abc");
 });
 
-Deno.test("Verify computed recalculates correctly with internal dependency updates", () => {
-    const a = ref(0);
-    let counter = 0;
-    computed(() => {
-        counter++;
-        if (counter > 100) return;
-        Sync.Tracking.add(a);
-        a.val = 1; // 2, 4
-    }).follow(() => {}); // 1
-    assertStrictEquals(counter, 2);
-    a.val = 2; // 3
+Deno.test("Combine should work with object of different types", () => {
+	const num = ref(42);
+	const str = ref("hello");
+	const bool = ref(true);
 
-    assertStrictEquals(counter, 4); // 4 times, no less, no more
+	const combined = combine({ num, str, bool });
+	const results: { num: number; str: string; bool: boolean }[] = [];
+
+	combined.follow((vals) => results.push(vals), true);
+
+	num.val = 100;
+	str.val = "world";
+	bool.val = false;
+
+	assertStrictEquals(results.length, 4);
+	assertStrictEquals(results[0]!.num, 42);
+	assertStrictEquals(results[0]!.str, "hello");
+	assertStrictEquals(results[0]!.bool, true);
+	assertStrictEquals(results[3]!.num, 100);
+	assertStrictEquals(results[3]!.str, "world");
+	assertStrictEquals(results[3]!.bool, false);
+});
+
+Deno.test("Combine derived chain", () => {
+	const a = ref(1);
+	const b = ref(2);
+	const sum = combine({ a, b }).derive(({ a, b }) => a + b);
+
+	const results: number[] = [];
+	sum.follow((val) => results.push(val), true);
+
+	a.val = 10;
+	b.val = 20;
+
+	assertStrictEquals(results.length, 3);
+	assertStrictEquals(results[0], 3);
+	assertStrictEquals(results[1], 12);
+	assertStrictEquals(results[2], 30);
 });
 
 Deno.test("Infinite loop test", () => {
-    let counter = 0;
-    const a = new Sync(() => {
-        counter++;
-        if (counter > 100) return;
-        a.val;
-    });
-    a.val;
+	let counter = 0;
+	const a = new Sync(() => {
+		counter++;
+		if (counter > 100) return;
+		a.val;
+	});
+	a.val;
 
-    assertStrictEquals(counter, 1);
+	assertStrictEquals(counter, 1);
 });
 
 Deno.test("No stop leak", () => {
-    let counter = 0;
-    // deno-lint-ignore prefer-const
-    let unfollow: Sync.Unfollower;
-    const a = new Sync(() => {
-        if (typeof unfollow !== "undefined") {
-            unfollow();
-        }
+	let counter = 0;
+	// deno-lint-ignore prefer-const
+	let unfollow: Sync.Unfollower;
+	const a = new Sync(() => {
+		if (typeof unfollow !== "undefined") {
+			unfollow();
+		}
 
-        return () => {
-            counter++;
-        };
-    });
-    unfollow = a.follow(() => {});
-    unfollow();
-    assertStrictEquals(counter, 1);
-});
-
-Deno.test("Computed should not crash if a dependency triggers follow() inline during initialization", () => {
-    const a = ref(0);
-
-    // This will try to follow `a` inline during computed's setup
-    const b = computed(() => {
-        // Synchronously subscribe to `a` — this will call a.follow(update)
-        // *before* computed() assigns update in the sync callback if there's a bug.
-        a.follow(() => {});
-        return a.val + 1;
-    });
-
-    // If bug exists, this line would throw (cannot call undefined update)
-    const initial = b.val;
-
-    assertStrictEquals(initial, 1);
-
-    a.val = 41;
-    assertStrictEquals(b.val, 42);
+		return () => {
+			counter++;
+		};
+	});
+	unfollow = a.follow(() => {});
+	unfollow();
+	assertStrictEquals(counter, 1);
 });

--- a/core/signals.ts
+++ b/core/signals.ts
@@ -17,14 +17,6 @@ export declare namespace Sync {
     type Unfollower = () => void;
 
     /**
-     * A function type that gets the value of a signal.
-     * Used primarily in computed signals to retrieve the current value.
-     *
-     * @template T - The type of the value returned by the getter.
-     */
-    type Getter<T> = () => T;
-
-    /**
      * A function type that sets the value of a signal.
      * Used primarily in sync signals to update the signal's value.
      *
@@ -91,14 +83,11 @@ export class Sync<T = never> {
 
     /**
      * Gets the current value of the signal.
-     * This method also adds the signal to the dependency tracking system, ensuring that any function
-     * depending on this signal will automatically update when the signal's value changes.
      *
      * @returns The current value of the signal.
      */
     public get(): T {
-        Tracking.add(this);
-        if (!this.#stopper) { // if is not active
+        if (!this.#stopper) {
             this.follow(noop)();
         }
         return this.last;
@@ -189,12 +178,12 @@ export class Sync<T = never> {
     }
 
     /**
-     * Derives a new computed signal based on the value of this signal.
-     * The computed signal will be updated whenever this signal's value changes.
-     * This provides a simple way to transform a signal's value without creating dependencies manually.
+     * Derives a new signal based on the value of this signal.
+     * The derived signal will be updated whenever this signal's value changes.
+     * This provides a simple way to transform a signal's value.
      *
      * @param getter - A function that computes a new value based on the current value of the signal.
-     * @returns A new computed signal that derives its value from this signal.
+     * @returns A new signal that derives its value from this signal.
      *
      * @example
      * ```ts
@@ -205,12 +194,7 @@ export class Sync<T = never> {
      * ```
      */
     public derive<R>(getter: (value: T) => R): Sync<R> {
-        return computed(() => {
-            // Add `this` as signal manually
-            Tracking.add(this);
-            // Ignore other signals that may be called during getting the val and calling getter.
-            return Tracking.track(() => getter(this.get()));
-        });
+        return sync<R>((set) => this.follow((value) => set(getter(value)), true));
     }
 
     /**
@@ -224,7 +208,7 @@ export class Sync<T = never> {
      * ```ts
      * const count = ref(0);
      * const element = count.pipe(signal =>
-     *   div().textContent(computed(() => `Count: ${signal.get()}`))
+     *   div().textContent(signal.derive(n => `Count: ${n}`))
      * );
      * ```
      */
@@ -232,48 +216,6 @@ export class Sync<T = never> {
         return fn(this);
     }
 }
-
-export declare namespace Sync {
-    /**
-     * Dependency tracking system that allows signals to automatically detect and
-     * manage dependencies in computed values.
-     */
-    namespace Tracking {
-        /**
-         * Adds a signal to the current dependency tracking context.
-         * When a signal's value is accessed inside a tracked function, this method
-         * is called to register the signal as a dependency.
-         *
-         * @param signal - The signal to add to the dependency system.
-         */
-        function add(signal: Sync<unknown>): void;
-
-        /**
-         * Tracks a function and its dependencies by creating a tracking context.
-         * Any signals accessed during the function's execution will be registered as dependencies
-         * through the provided callback.
-         *
-         * @template R - The return type of the tracked function.
-         * @param callAndTrack - A function that will be tracked for dependencies.
-         * @param callback - An optional callback function invoked when a signal is accessed.
-         * @returns The result of the `callAndTrack` function.
-         */
-        function track<R>(callAndTrack: () => R, callback?: (signal: Sync<unknown>) => unknown): R;
-    }
-}
-
-let dependencyTrackingStack: (((signal: Sync<unknown>) => unknown) | undefined)[] = [];
-let Tracking = (Sync.Tracking = {
-    add(signal: Sync<unknown>): void {
-        dependencyTrackingStack.at(-1)?.(signal);
-    },
-    track<R>(callAndTrack: () => R, callback?: (signal: Sync<unknown>) => unknown): R {
-        dependencyTrackingStack.push(callback);
-        let result = callAndTrack();
-        dependencyTrackingStack.pop();
-        return result;
-    },
-});
 
 export declare namespace Sync {
     /**
@@ -382,58 +324,41 @@ export let sync = <T = never>(start: Sync.Starter<T>): Sync<T> => new Sync(start
 export let ref = <T>(initial: T): Sync.Ref<T> => new Sync.Ref(initial);
 
 /**
- * Creates a computed signal that automatically tracks its dependencies.
- * A computed signal derives its value from other signals and updates automatically
- * when any of its dependencies change.
+ * Combines multiple signals into a single signal that holds their values as a tuple.
+ * The combined signal updates whenever any of the input signals change.
  *
- * @template T The type of the computed value.
- * @param getter A function that computes the value based on other signals.
- * @returns A read-only signal that updates when its dependencies change.
+ * @template T Array of signal types
+ * @param signals A tuple of signals to combine
+ * @returns A signal that holds a tuple of all the input signal values
  *
  * @example
  * ```ts
  * const firstName = ref('John');
  * const lastName = ref('Doe');
- * const fullName = computed(() => `${firstName.val} ${lastName.val}`);
+ * const fullName = combine([firstName, lastName]).derive(([first, last]) => `${first} ${last}`);
  *
  * fullName.follow(console.log); // Logs: "John Doe"
  * firstName.val = 'Jane'; // Logs: "Jane Doe"
  * ```
  */
-export let computed = <T>(getter: Sync.Getter<T>): Sync<T> => {
-    type DependencyDetails =
-        | [unfollower: Sync.Unfollower, version: boolean]
-        | [unfollower: Sync.Unfollower];
-
-    let dependencies = new Map<Sync<unknown>, DependencyDetails>();
-
-    let currentVersion = false;
-    let details: DependencyDetails | undefined;
-    let update: () => void;
-
-    let self = sync<T>((notify) => {
-        update = () => {
-            currentVersion = !currentVersion;
-            notify(
-                Tracking.track(getter, (dependency) => {
-                    details = dependencies.get(dependency);
-                    if (!details) dependencies.set(dependency, details = [dependency.follow(update)]);
-                    details[1] = currentVersion;
-                }),
-            );
-
-            for (let [dependency, [unfollow, version]] of dependencies) {
-                if (version === currentVersion) continue;
+export let combine = <T extends Record<string, Sync<any>>>(signals: T): Sync<{ [K in keyof T]: T[K]["val"] }> => {
+    return sync((set) => {
+        let entries = Object.entries(signals) as [keyof T, Sync<any>][];
+        let values = {} as { [K in keyof T]: T[K] extends Sync<infer V> ? V : never };
+        let unfollows: Sync.Unfollower[] = [];
+        for (let [key, signal] of entries) {
+            values[key] = signal.get();
+            unfollows.push(signal.follow((value) => {
+                values[key] = value;
+                set({ ...values });
+            }));
+        }
+        // Set initial value after subscribing to all signals
+        set({ ...values });
+        return () => {
+            for (let unfollow of unfollows) {
                 unfollow();
-                dependencies.delete(dependency);
             }
         };
-        update();
-
-        return () => {
-            dependencies.forEach(([unfollow]) => unfollow());
-            dependencies.clear();
-        };
     });
-    return self;
 };

--- a/examples/mix-example.ts
+++ b/examples/mix-example.ts
@@ -1,11 +1,4 @@
-import {
-    Builder,
-    Lifecycle,
-    ref,
-    Sync,
-    sync,
-    tags,
-} from "@purifyjs/core";
+import { Builder, Lifecycle, ref, Sync, sync, tags } from "@purifyjs/core";
 
 const { button, ul, li, input } = tags;
 

--- a/examples/mix-example.ts
+++ b/examples/mix-example.ts
@@ -1,6 +1,5 @@
 import {
     Builder,
-    computed,
     Lifecycle,
     ref,
     Sync,
@@ -19,7 +18,7 @@ const time = sync<number>((set) => {
 
 const count = ref(0);
 const double = count.derive((count) => count * 2);
-const half = computed(() => count.val * 0.5);
+const half = count.derive((c) => c * 0.5);
 
 new Builder(document.body).append$(
     button()


### PR DESCRIPTION
Fixes: #8 

BREAKING CHANGE: `computed()` has been removed to prevent abuse of automatic dependency tracking. Use `signal.derive()` for single-signal transformations and the new `combine()` utility for multiple signals. Changes:
- Remove `computed()` and `Sync.Tracking` namespace
- Simplify `derive()` impl
- Add `combine()` to combine multiple signals into one signal
- Update all tests to use new API
- Update example to use `derive()` instead of `computed()` 

Size reduction:
- Bundled: 2256 → 2085 bytes (-7.6%)
- Gzipped: 1168 → 1073 bytes (-8.1%) 

Migration:
```ts
// Before
const fullName = computed(() => `${first.get()} ${last.get()}`);
// After
const fullName = combine({ first, last })
  .derive(({ first, last }) => `${first} ${last}`);